### PR TITLE
Fix link to full plate stl

### DIFF
--- a/case/plate/README.md
+++ b/case/plate/README.md
@@ -17,6 +17,6 @@ Also available on [Thingiverse](https://www.thingiverse.com/thing:4971965)
   - [bot left](bot_left.stl)
   - [bot right](bot_right.stl)
 - No Rotary Encoders/Default
-  - [full plate](no_encoders.stl)
+  - [full plate](full_plate.stl)
 
 *Note: The thinnest edge is the right edge, otherwise it won't fit into the case*


### PR DESCRIPTION
The file name for the full plate was changed from `no_encoder.stl` to `full_plate.stl`.
I have adjusted the link in the readme accordingly. 