### PR TITLE
Documentation Overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ To build your own dumbpad you will need to follow a couple of steps to get start
 You can choose from one of the five different versions shown in the step above.
 #### 2. Order your parts. 
 Every board needs at least the following components but check the right folder for your parts list.
-- 1 x PCB
-- 16 x MX-style mechanical switches
-- 17 x 1n4148 diodes (thru hole)
-- 1 x Arduino Pro Micro or pin-compatible ATmega32u4-based MCU (Or teensy for the teensy version)
-- (optional) 1 x EC11 rotary encoder with pushbutton (7-pin)
-- (optional) 1 x 6mm tactile switch (to reset MCU)
-- LEDS and OLED required for different configurations
+* 1 x PCB
+* 16 x MX-style mechanical switches
+* 17 x 1n4148 diodes (thru hole)
+* 1 x Arduino Pro Micro or pin-compatible ATmega32u4-based MCU (Or teensy for the teensy version)
+* (optional) 1 x EC11 rotary encoder with pushbutton (7-pin)
+* (optional) 1 x 6mm tactile switch (to reset MCU)
+* LEDS and OLED required for different configurations
 
 #### 3. Assemble your dumbpad
 For this step you will need a minimum of a soldering iron and a pair of tweezers

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# dumbpad
+
+ <a href="http://www.amitmerchant.com/electron-markdownify"><img src="https://imgur.com/9RIxP0s.png" alt="dumbpad logo" width="150"></a>
+
 
 dumbpad is a simple macropad with support for up to two rotary encoders, designed to use [QMK](https://qmk.fm/) firmware.
 
@@ -8,13 +10,9 @@ dumbpad is a simple macropad with support for up to two rotary encoders, designe
 
 Top two boards are v0.2, bottom two are v0.7. Bottom right is v0.7 with components soldered to the bottom, moving the rotary encoder to the right side.
 
-![v0.6_dualencoder by chicocode](https://i.imgur.com/OkSRXWT.jpg)
-
-[v0.6_dualencoder](https://www.github.com/imchipwood/dumbpad/tree/v0.6_dualencoder) by chicocode, boards likely manufactured by [JLC PCB](https://www.jlcpcb.com)
-
 ## In this repository
 
-This repo is separated into three main folders:
+This repo is separated into five main folders:
 
 - [combo](./combo) houses the main PCB design which includes support for up to two rotary encoders and three status LEDs intended for the Pro Micro.
 - [combo_oled](./combo_oled) was created by [KEEBD](https://keebd.com) and replaces the layer LED/Resistors with OLED display support and converted to KiCad.
@@ -23,6 +21,32 @@ This repo is separated into three main folders:
 - [hotswap_rgb - v3.x](./hotswap_rgb) dumbpad featuring per-key RGB and Hotswap sockets
 
 Each folder includes the Eagle or KiCad files as well as exported Gerber files for manufacturing. These folders also include readmes specific to those designs - check them for more info.
+
+## Getting Started
+To build your own dumbpad you will need to follow a couple of steps to get started. Described below are the minimal steps you will need to take to to assemble one dumbpad but every board configuration might require different steps. 
+#### 1. Choose version. 
+You can choose from one of the five different versions shown in the step above.
+#### 2. Order your parts. 
+Every board needs at least the following components but check the right folder for your parts list.
+- 1 x PCB
+- 16 x MX-style mechanical switches
+- 17 x 1n4148 diodes (thru hole)
+- 1 x Arduino Pro Micro or pin-compatible ATmega32u4-based MCU (Or teensy for the teensy version)
+- (optional) 1 x EC11 rotary encoder with pushbutton (7-pin)
+- (optional) 1 x 6mm tactile switch (to reset MCU)
+- LEDS and OLED required for different configurations
+
+#### 3. Assemble your dumbpad
+For this step you will need a minimum of a soldering iron and a pair of tweezers
+- Solder the diodes, switches, and Arduino Pro Micro (Or teensy) to the PCB
+
+#### 4. Flash your firmware
+You can use QMK to create and flash firmware to your dumbpad. You can configure every key to you can use the QMK configurator. Head over to the [QMK configurator](https://config.qmk.fm/#/friedrich/LAYOUT) and select dumbpad/[your version]. Once you have configured your baord, click on compile and then on firmware to download the firmware. Check [qmk_firmware/keyboards/dumbpad](https://github.com/qmk/qmk_firmware/tree/master/keyboards/dumbpad) for compiling & uploading instructions
+
+Once you have downloaded a .HEX firmware file we can head over to the [QMK toolbox](https://github.com/qmk/qmk_toolbox/releases) and flash the firmware. Plug in your dumbpad to your computer and set your QMK toolbox to ATmega32U4 for most Arduino Pro Micros. You will need to press your 6mm tacticle switch twice to enter the bootloader, wait for your computer to reconize the dumbpad and click on flash.
+
+
+
 
 ### Features
 

--- a/combo/README.md
+++ b/combo/README.md
@@ -88,10 +88,10 @@ You may also choose not to use any rotary encoders if you like!
 
 ### Bill Of Materials
 
-- Cherry-style mechanical switches
-- EC11 rotary encoder with pushbutton (7-pin) - one or two depending on your desired configuration
-- 1n4148 diodes (thru hole) - one per switch and rotary encoder (if using clickable encoder(s))
-- 1x Arduino Pro Micro or pin-compatible ATmega32u4-based MCU
-- (optional) 3x 3mm LEDs
-  - (optional) 3x 3mm resistors (for limiting current in LEDs)
-- (optional) 6mm SPST switch for resetting MCU
+- 1 x PCB
+- 16 x MX-style mechanical switches
+- 17 x 1n4148 diodes (thru hole)
+- 1 x Arduino Pro Micro or pin-compatible ATmega32u4-based MCU (Or teensy for the teensy version)
+- 1x or 2x EC11 rotary encoder with pushbutton (7-pin)
+- (optional) 1 x 6mm tactile switch (to reset MCU)
+- (optional) 3x 3mm resistors (for limiting current in LEDs)

--- a/combo_oled/README.md
+++ b/combo_oled/README.md
@@ -23,19 +23,19 @@ Version of the original dumbpad but with support for an OLED display in place of
 ![back](img/dumbpad_oled_v1_2_back.png)
 
 
-### Parts
+### Bill of materials
+- 1 x PCB
+- 16 x MX-style mechanical switches
+- 17 x 1n4148 diodes (thru hole)
+- 1 x Arduino Pro Micro or pin-compatible ATmega32u4-based MCU (Or teensy for the teensy version)
+- 1 x or 2x EC11 rotary encoder with pushbutton (7-pin)
+- 1 x 6mm tactile switch (to reset MCU)
+- 1 x 0.91" 128X32 OLED Display
 
-* 16 x Cherry-style mechanical switches
-* 17 x 1n4148 diodes (thru hole)
-* 1 x Arduino Pro Micro or pin-compatible ATmega32u4-based MCU
-* 1 x 0.91" 128X32 OLED Display
-* (optional) 1 x EC11 rotary encoder with pushbutton (7-pin)
-* (optional) 1 x 6mm tactile switch (to reset MCU)
 
 ## OLED Firmware
 
 The OLED firmware is different and can be found here [Firmware](https://docs.keebd.com/firmware/)
 
-## Making the PCB
-
-Submit either the KiCad `.kicad_pcb` or the gerber files to your prefered PCB manufacturer.
+## How to build 
+You can follow the instreuctions from the main [readme](https://github.com/imchipwood/dumbpad#getting-started) or follow the instructiosn in this [blog](https://www.timowielink.com/post/how-to-build-a-macropad) from [Timo Wielink](https://github.com/TimoWielink)

--- a/combo_oled/README.md
+++ b/combo_oled/README.md
@@ -34,7 +34,7 @@ Version of the original dumbpad but with support for an OLED display in place of
 
 ## OLED Firmware
 
-The OLED firmware is different and can be found here [Firmware](https://github.com/keebd/qmk_firmware/tree/keebd/keyboards/dumbpad/combo_oled)
+The OLED firmware is different and can be found here [Firmware](https://docs.keebd.com/firmware/)
 
 ## Making the PCB
 

--- a/combo_teensy/README.md
+++ b/combo_teensy/README.md
@@ -66,10 +66,13 @@ You may also choose not to use any rotary encoders if you like!
 
 ### Bill Of Materials
 
-- Cherry-style mechanical switches
-- EC11 rotary encoder with pushbutton (7-pin) - one or two depending on your desired configuration
-- 1n4148 diodes (thru hole) - one per switch and rotary encoder (if using clickable encoder(s))
-- 1x Teensy2.0 or pin-compatible ATmega32u4-based MCU
+1 x PCB
+16 x MX-style mechanical switches
+17 x 1n4148 diodes (thru hole)
+1 x Teensy2.0 
+1 x or 2 x EC11 rotary encoder with pushbutton (7-pin)
 - (optional) 3x 3mm LEDs
-  - (optional) 3x 3mm resistors (for limiting current in LEDs)
+- (optional) 3x 3mm resistors (for limiting current in LEDs)
 - (optional) 6mm SPST switch for resetting MCU
+
+

--- a/combo_teensy/README.md
+++ b/combo_teensy/README.md
@@ -1,4 +1,4 @@
-# dumbpad/combo
+# dumbpad/combo_teensy
 
 This folder houses the dumbpad "combo_teensy" design - this layout uses custom "combo" Cherry MX + EC11 rotary encoder sockets that allow a single PCB design to support both single- and dual-encoder layouts. It uses Teensy2.0 microcontroller instead of a Pro Micro
 

--- a/hotswap_rgb/README.md
+++ b/hotswap_rgb/README.md
@@ -23,7 +23,7 @@ Version of the original dumbpad that features Kailh Hotswap Sockets and (optiona
 ![back](img/dumbpad_v3_1_back.png)
 
 
-### Parts
+### Bill of materials
 
 * 16x Kailh Hotswap Sockets (rev 2)
 * 16x Cherry-style mechanical switches

--- a/reversible/README.md
+++ b/reversible/README.md
@@ -24,7 +24,7 @@ It is designed to run [QMK firmware](https://github.com/qmk/qmk_firmware) - chec
 #### Eagle PCB render
 ![dumbpad](dumbpad.png)
 
-### Parts
+### Bill of materials
 * 16x Cherry-style mechanical switches
 * 17x 1n4148 diodes (thru hole)
 * 1x Arduino Pro Micro or pin-compatible ATmega32u4-based MCU


### PR DESCRIPTION
I have been working on the alignment of the readme files between all the different versions. It seems like a lot of info is spread out over different files. Maybe we can rethink the main readme file.

I build a couple of different OLED versions to play with. Will be working on the combination of the OLED version and Hot-swap soon. I also wrote a [step-by-step guide](https://www.timowielink.com/post/how-to-build-a-macropad) that I linked in the OLED version. 

Also working on a small roadmap for the project:
-  Align documentation
-  Rethink folders and different versions
-  Build Oled Hot swap version
- Create WiKi to support installation documentation and QMK support


